### PR TITLE
Switch web3 and web3-eth-accounts to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   "dependencies": {
     "@openstfoundation/mosaic-contracts": "^0.10.0-alpha.1",
     "bn.js": "4.11.8",
-    "js-scrypt": "^0.2.0",
+    "js-scrypt": "^0.2.0"
+  },
+  "peerDependencies": {
     "web3": "1.0.0-beta.37",
     "web3-eth-accounts": "1.0.0-beta.37"
   },
@@ -60,7 +62,9 @@
     "wait-port": "^0.2.2",
     "webpack": "4.19.1",
     "webpack-cli": "3.1.0",
-    "webpack-uglify-js-plugin": "1.1.9"
+    "webpack-uglify-js-plugin": "1.1.9",
+    "web3": "1.0.0-beta.37",
+    "web3-eth-accounts": "1.0.0-beta.37"
   },
   "pre-commit": {
     "run": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,10 @@ const commonConfig = (target, babelTargets) => {
       path: path.resolve(__dirname, 'lib'),
       filename: `[name].${target}.js`,
     },
+    externals: {
+      web3: 'web3',
+      'web3-eth-accounts': 'web3-eth-accounts',
+    },
     plugins: [
       new webpack.NormalModuleReplacementPlugin(
         /\.\/AbiBinProvider-node\.js/,


### PR DESCRIPTION
FIXES #77 and also fixes the warnings on the webpack build for node.js.

On why it should be a peerDependency instead of a normal dependency, there are many articles on the internet that probably explain that better than I could.

One concise questionare for how to decide this (https://stackoverflow.com/a/34645112):

> When should you use peer dependencies?
> - When you are building a library to be used by other projects, and
> - This library is using some other library, and
> - You expect/need the user to work with that other library as well
