### PR TITLE
Facilitator.stake now returns nonce and msg hash

### DIFF
--- a/src/ContractInteract/EIP20CoGateway.js
+++ b/src/ContractInteract/EIP20CoGateway.js
@@ -336,7 +336,7 @@ class EIP20CoGateway {
       blockHeight,
       encodedAccount,
       accountProof,
-    ).then((tx) => Utils.sendTransaction(tx, txOptions));
+    ).then(tx => Utils.sendTransaction(tx, txOptions));
   }
 
   /**
@@ -421,7 +421,7 @@ class EIP20CoGateway {
       hashLock,
       blockHeight,
       storageProof,
-    ).then((tx) => Utils.sendTransaction(tx, txOptions));
+    ).then(tx => Utils.sendTransaction(tx, txOptions));
   }
 
   /**
@@ -533,8 +533,8 @@ class EIP20CoGateway {
       );
       return Promise.reject(err);
     }
-    return this.progressMintRawTx(messageHash, unlockSecret).then((tx) =>
-      Utils.sendTransaction(tx, txOptions),
+    return this.progressMintRawTx(messageHash, unlockSecret).then(
+      tx => Utils.sendTransaction(tx, txOptions),
     );
   }
 
@@ -581,8 +581,8 @@ class EIP20CoGateway {
       );
       return Promise.reject(err);
     }
-    return this.progressRedeemRawTx(messageHash, unlockSecret).then((tx) =>
-      Utils.sendTransaction(tx, txOptions),
+    return this.progressRedeemRawTx(messageHash, unlockSecret).then(
+      tx => Utils.sendTransaction(tx, txOptions),
     );
   }
 
@@ -739,7 +739,7 @@ class EIP20CoGateway {
       gasLimit,
       nonce,
       hashLock,
-    ).then((tx) => Utils.sendTransaction(tx, txOptions));
+    ).then(tx => Utils.sendTransaction(tx, txOptions));
   }
 
   /**
@@ -783,6 +783,11 @@ class EIP20CoGateway {
       const err = new TypeError(`Invalid hash lock: ${hashLock}.`);
       return Promise.reject(err);
     }
+    if (Utils.maxRewardTooBig(amount, gasPrice, gasLimit)) {
+      const err = new Error(`The maximum possible reward of gasPrice*gasLimit is greater than the redeem amount. It must be less.\n    gasPrice: ${gasPrice}\n    gasLimit: ${gasLimit}\n    redeem amount: ${amount}`);
+      return Promise.reject(err);
+    }
+
     const tx = this.contract.methods.redeem(
       amount,
       beneficiary,
@@ -811,9 +816,9 @@ class EIP20CoGateway {
       const err = new TypeError(`Invalid redeem amount: ${amount}.`);
       return Promise.reject(err);
     }
-    return this.getUtilityTokenContract().then((eip20ValueToken) => {
-      return eip20ValueToken.isAmountApproved(redeemer, this.address, amount);
-    });
+    return this.getUtilityTokenContract().then(
+      eip20ValueToken => eip20ValueToken.isAmountApproved(redeemer, this.address, amount),
+    );
   }
 
   /**
@@ -837,9 +842,9 @@ class EIP20CoGateway {
       const err = new TypeError(`Invalid redeem amount: ${amount}.`);
       return Promise.reject(err);
     }
-    return this.getUtilityTokenContract().then((eip20Token) => {
-      return eip20Token.approve(this.address, amount, txOptions);
-    });
+    return this.getUtilityTokenContract().then(
+      eip20Token => eip20Token.approve(this.address, amount, txOptions),
+    );
   }
 
   /**
@@ -861,10 +866,11 @@ class EIP20CoGateway {
   /**
    * Get the latest state root and block height.
    *
-   * @returns {Promise<Object>} Promise object that resolves to object containing state root and block height.
+   * @returns {Promise<Object>} Promise object that resolves to object containing state root and
+   *                            block height.
    */
   async getLatestAnchorInfo() {
-    return this.getAnchor().then((anchor) => anchor.getLatestInfo());
+    return this.getAnchor().then(anchor => anchor.getLatestInfo());
   }
 
   /**

--- a/src/ContractInteract/EIP20Gateway.js
+++ b/src/ContractInteract/EIP20Gateway.js
@@ -517,7 +517,7 @@ class EIP20Gateway {
       const err = new TypeError(`Invalid hash lock: ${hashLock}.`);
       return Promise.reject(err);
     }
-    if (EIP20Gateway._maxRewardTooBig(amount, gasPrice, gasLimit)) {
+    if (Utils.maxRewardTooBig(amount, gasPrice, gasLimit)) {
       const err = new Error(`The maximum possible reward of gasPrice*gasLimit is greater than the stake amount. It must be less.\n    gasPrice: ${gasPrice}\n    gasLimit: ${gasLimit}\n    stake amount: ${amount}`);
       return Promise.reject(err);
     }
@@ -1096,11 +1096,6 @@ class EIP20Gateway {
 
     const tx = this.contract.methods.activateGateway(coGatewayAddress);
     return Promise.resolve(tx);
-  }
-
-  static _maxRewardTooBig(amount, gasPrice, gasLimit) {
-    const maxReward = new BN(gasPrice).mul(new BN(gasLimit));
-    return (maxReward.gt(new BN(amount)));
   }
 }
 

--- a/src/ContractInteract/EIP20Gateway.js
+++ b/src/ContractInteract/EIP20Gateway.js
@@ -405,7 +405,7 @@ class EIP20Gateway {
       blockHeight,
       encodedAccount,
       accountProof,
-    ).then((tx) => Utils.sendTransaction(tx, txOptions));
+    ).then(tx => Utils.sendTransaction(tx, txOptions));
   }
 
   /**
@@ -473,7 +473,7 @@ class EIP20Gateway {
       gasLimit,
       nonce,
       hashLock,
-    ).then((tx) => Utils.sendTransaction(tx, txOptions));
+    ).then(tx => Utils.sendTransaction(tx, txOptions));
   }
 
   /**
@@ -517,6 +517,11 @@ class EIP20Gateway {
       const err = new TypeError(`Invalid hash lock: ${hashLock}.`);
       return Promise.reject(err);
     }
+    if (EIP20Gateway._maxRewardTooBig(amount, gasPrice, gasLimit)) {
+      const err = new Error(`The maximum possible reward of gasPrice*gasLimit is greater than the stake amount. It must be less.\n    gasPrice: ${gasPrice}\n    gasLimit: ${gasLimit}\n    stake amount: ${amount}`);
+      return Promise.reject(err);
+    }
+
     const tx = this.contract.methods.stake(
       amount,
       beneficiary,
@@ -548,8 +553,8 @@ class EIP20Gateway {
       );
       return Promise.reject(err);
     }
-    return this.progressStakeRawTx(messageHash, unlockSecret).then((tx) =>
-      Utils.sendTransaction(tx, txOptions),
+    return this.progressStakeRawTx(messageHash, unlockSecret).then(
+      tx => Utils.sendTransaction(tx, txOptions),
     );
   }
 
@@ -624,7 +629,7 @@ class EIP20Gateway {
       blockNumber,
       hashLock,
       storageProof,
-    ).then((tx) => Utils.sendTransaction(tx, txOptions));
+    ).then(tx => Utils.sendTransaction(tx, txOptions));
   }
 
   /**
@@ -736,8 +741,8 @@ class EIP20Gateway {
       );
       return Promise.reject(err);
     }
-    return this.progressUnstakeRawTx(messageHash, unlockSecret).then((tx) =>
-      Utils.sendTransaction(tx, txOptions),
+    return this.progressUnstakeRawTx(messageHash, unlockSecret).then(
+      tx => Utils.sendTransaction(tx, txOptions),
     );
   }
 
@@ -901,38 +906,38 @@ class EIP20Gateway {
       const err = new TypeError(`Invalid stake amount: ${amount}.`);
       return Promise.reject(err);
     }
-    return this.getValueTokenContract().then((eip20ValueToken) => {
-      return eip20ValueToken.isAmountApproved(
+    return this.getValueTokenContract().then(
+      eip20ValueToken => eip20ValueToken.isAmountApproved(
         stakerAddress,
         this.address,
         amount,
-      );
-    });
+      ),
+    );
   }
 
   /**
    * Check if the account has approved gateway contract for bounty amount transfer.
    *
-   * @param {string} facilityAddress Facilitator address.
+   * @param {string} facilitatorAddress Facilitator address.
    *
    * @returns {Promise<boolean>} Promise that resolves to `true` if approved.
    */
-  isBountyAmountApproved(facilityAddress) {
-    if (!Web3.utils.isAddress(facilityAddress)) {
+  isBountyAmountApproved(facilitatorAddress) {
+    if (!Web3.utils.isAddress(facilitatorAddress)) {
       const err = new TypeError(
-        `Invalid facilitator address: ${facilityAddress}.`,
+        `Invalid facilitator address: ${facilitatorAddress}.`,
       );
       return Promise.reject(err);
     }
-    return this.getBaseTokenContract().then((eip20BaseToken) => {
-      return this.getBounty().then((bounty) => {
-        return eip20BaseToken.isAmountApproved(
-          facilityAddress,
+    return this.getBaseTokenContract().then(
+      eip20BaseToken => this.getBounty().then(
+        bounty => eip20BaseToken.isAmountApproved(
+          facilitatorAddress,
           this.address,
           bounty,
-        );
-      });
-    });
+        ),
+      ),
+    );
   }
 
   /**
@@ -988,8 +993,8 @@ class EIP20Gateway {
       const err = new TypeError(`Invalid stake amount: ${amount}.`);
       return Promise.reject(err);
     }
-    return this.getValueTokenContract().then((eip20Token) =>
-      eip20Token.approve(this.address, amount, txOptions),
+    return this.getValueTokenContract().then(
+      eip20Token => eip20Token.approve(this.address, amount, txOptions),
     );
   }
 
@@ -1010,11 +1015,11 @@ class EIP20Gateway {
       const err = new TypeError(`Invalid from address: ${txOptions.from}.`);
       return Promise.reject(err);
     }
-    return this.getBaseTokenContract().then((eip20BaseToken) => {
-      return this.getBounty().then((bounty) =>
-        eip20BaseToken.approve(this.address, bounty, txOptions),
-      );
-    });
+    return this.getBaseTokenContract().then(
+      eip20BaseToken => this.getBounty().then(
+        bounty => eip20BaseToken.approve(this.address, bounty, txOptions),
+      ),
+    );
   }
 
   /**
@@ -1036,10 +1041,11 @@ class EIP20Gateway {
   /**
    * Get the latest state root and block height.
    *
-   * @returns {Promise<Object>} Promise object that resolves to object containing state root and block height.
+   * @returns {Promise<Object>} Promise object that resolves to object containing state root and
+   *                            block height.
    */
   async getLatestAnchorInfo() {
-    return this.getAnchor().then((anchor) => anchor.getLatestInfo());
+    return this.getAnchor().then(anchor => anchor.getLatestInfo());
   }
 
   /**
@@ -1070,8 +1076,8 @@ class EIP20Gateway {
       return Promise.reject(err);
     }
 
-    return this.activateGatewayRawTx(coGatewayAddress).then((tx) =>
-      Utils.sendTransaction(tx, txOptions),
+    return this.activateGatewayRawTx(coGatewayAddress).then(
+      tx => Utils.sendTransaction(tx, txOptions),
     );
   }
 
@@ -1090,6 +1096,11 @@ class EIP20Gateway {
 
     const tx = this.contract.methods.activateGateway(coGatewayAddress);
     return Promise.resolve(tx);
+  }
+
+  static _maxRewardTooBig(amount, gasPrice, gasLimit) {
+    const maxReward = new BN(gasPrice).mul(new BN(gasLimit));
+    return (maxReward.gt(new BN(amount)));
   }
 }
 

--- a/src/ContractInteract/UtilityToken.js
+++ b/src/ContractInteract/UtilityToken.js
@@ -208,8 +208,8 @@ class UtilityToken {
       const err = new TypeError(`Invalid from address: ${txOptions.from}.`);
       return Promise.reject(err);
     }
-    return this.approveRawTx(spenderAddress, amount).then((tx) =>
-      Utils.sendTransaction(tx, txOptions),
+    return this.approveRawTx(spenderAddress, amount).then(
+      tx => Utils.sendTransaction(tx, txOptions),
     );
   }
 
@@ -284,9 +284,7 @@ class UtilityToken {
       return Promise.reject(err);
     }
     return this.allowance(ownerAddress, spenderAddress).then(
-      (approvedAllowance) => {
-        return new BN(amount).lte(new BN(approvedAllowance));
-      },
+      approvedAllowance => new BN(amount).lte(new BN(approvedAllowance)),
     );
   }
 
@@ -319,8 +317,8 @@ class UtilityToken {
       return Promise.reject(err);
     }
 
-    return this.setCoGatewayRawTx(coGateway).then((tx) =>
-      Utils.sendTransaction(tx, txOptions),
+    return this.setCoGatewayRawTx(coGateway).then(
+      tx => Utils.sendTransaction(tx, txOptions),
     );
   }
 

--- a/src/Facilitator/index.js
+++ b/src/Facilitator/index.js
@@ -37,9 +37,7 @@ class Facilitator {
     }
     if (!Web3.utils.isAddress(mosaic.origin.contractAddresses.EIP20Gateway)) {
       const err = new TypeError(
-        `Invalid Gateway address: ${
-          mosaic.origin.contractAddresses.EIP20Gateway
-        }.`,
+        `Invalid Gateway address: ${mosaic.origin.contractAddresses.EIP20Gateway}.`,
       );
       throw err;
     }
@@ -47,9 +45,7 @@ class Facilitator {
       !Web3.utils.isAddress(mosaic.auxiliary.contractAddresses.EIP20CoGateway)
     ) {
       const err = new TypeError(
-        `Invalid CoGateway address: ${
-          mosaic.auxiliary.contractAddresses.EIP20CoGateway
-        }.`,
+        `Invalid CoGateway address: ${mosaic.auxiliary.contractAddresses.EIP20CoGateway}.`,
       );
       throw err;
     }
@@ -67,7 +63,6 @@ class Facilitator {
     this.stake = this.stake.bind(this);
     this.progressStake = this.progressStake.bind(this);
     this.confirmStakeIntent = this.confirmStakeIntent.bind(this);
-    this._getProof = this._getProof.bind(this);
     this.progressStakeMessage = this.progressStakeMessage.bind(this);
     this.performProgressStake = this.performProgressStake.bind(this);
     this.performProgressMint = this.performProgressMint.bind(this);
@@ -303,14 +298,10 @@ class Facilitator {
 
     if (!new BN(txOptions.value).eq(new BN(bounty))) {
       logger.error(
-        `  - Value in transaction option ${
-          txOptions.value
-        } is not equal to the bounty amount ${bounty}`,
+        `  - Value in transaction option ${txOptions.value} is not equal to the bounty amount ${bounty}`,
       );
       const err = new Error(
-        `Value passed in transaction object ${
-          txOptions.value
-        } must be equal to bounty amount ${bounty}`,
+        `Value passed in transaction object ${txOptions.value} must be equal to bounty amount ${bounty}`,
       );
       return Promise.reject(err);
     }
@@ -468,9 +459,7 @@ class Facilitator {
 
     if (!Web3.utils.isAddress(txOptionAuxiliary.from)) {
       const err = new TypeError(
-        `Invalid auxiliary chain facilitator address: ${
-          txOptionAuxiliary.from
-        }.`,
+        `Invalid auxiliary chain facilitator address: ${txOptionAuxiliary.from}.`,
       );
       return Promise.reject(err);
     }
@@ -593,9 +582,7 @@ class Facilitator {
 
     if (!Web3.utils.isAddress(txOptionAuxiliary.from)) {
       const err = new TypeError(
-        `Invalid auxiliary chain facilitator address: ${
-          txOptionAuxiliary.from
-        }.`,
+        `Invalid auxiliary chain facilitator address: ${txOptionAuxiliary.from}.`,
       );
       return Promise.reject(err);
     }
@@ -737,9 +724,9 @@ class Facilitator {
     logger.info(`  - CoGateway's inbox message hash is ${mintMessageStatus}`);
 
     if (
-      mintMessageStatus === MessageStatus.DECLARED ||
-      mintMessageStatus === MessageStatus.PROGRESSED ||
-      mintMessageStatus === MessageStatus.REVOKED
+      mintMessageStatus === MessageStatus.DECLARED
+      || mintMessageStatus === MessageStatus.PROGRESSED
+      || mintMessageStatus === MessageStatus.REVOKED
     ) {
       logger.win('  - Stake intent already confirmed on CoGateway');
       return Promise.resolve(true);
@@ -895,9 +882,9 @@ class Facilitator {
     logger.info(`  - Gateway's inbox message hash is ${unstakeMessageStatus}`);
 
     if (
-      unstakeMessageStatus === MessageStatus.DECLARED ||
-      unstakeMessageStatus === MessageStatus.PROGRESSED ||
-      unstakeMessageStatus === MessageStatus.REVOKED
+      unstakeMessageStatus === MessageStatus.DECLARED
+      || unstakeMessageStatus === MessageStatus.PROGRESSED
+      || unstakeMessageStatus === MessageStatus.REVOKED
     ) {
       logger.win('  - Redeem intent already confirmed on Gateway');
       return Promise.resolve(true);
@@ -978,9 +965,7 @@ class Facilitator {
     }
     if (!Web3.utils.isAddress(txOptionOrigin.from)) {
       const err = new TypeError(
-        `Invalid from address ${
-          txOptionOrigin.from
-        } in origin transaction options.`,
+        `Invalid from address ${txOptionOrigin.from} in origin transaction options.`,
       );
       return Promise.reject(err);
     }
@@ -992,9 +977,7 @@ class Facilitator {
     }
     if (!Web3.utils.isAddress(txOptionAuxiliary.from)) {
       const err = new TypeError(
-        `Invalid from address ${
-          txOptionAuxiliary.from
-        } in auxiliary transaction options.`,
+        `Invalid from address ${txOptionAuxiliary.from} in auxiliary transaction options.`,
       );
       return Promise.reject(err);
     }
@@ -1085,18 +1068,16 @@ class Facilitator {
 
     const stakeMessageStatus = await this.gateway
       .getOutboxMessageStatus(messageHash)
-      .catch((exception) => {
-        return Promise.reject(exception);
-      });
+      .catch(exception => Promise.reject(exception));
 
     logger.info(
       `  - Gateway's outbox message status is ${stakeMessageStatus}`,
     );
 
     if (
-      stakeMessageStatus === MessageStatus.UNDECLARED ||
-      stakeMessageStatus === MessageStatus.REVOCATION_DECLARED ||
-      stakeMessageStatus === MessageStatus.REVOKED
+      stakeMessageStatus === MessageStatus.UNDECLARED
+      || stakeMessageStatus === MessageStatus.REVOCATION_DECLARED
+      || stakeMessageStatus === MessageStatus.REVOKED
     ) {
       logger.error('  - Cannot perform progress stake.');
       const err = Error('Message cannot be progressed.');
@@ -1151,18 +1132,16 @@ class Facilitator {
 
     const mintMessageStatus = await this.coGateway
       .getInboxMessageStatus(messageHash)
-      .catch((exception) => {
-        return Promise.reject(exception);
-      });
+      .catch(exception => Promise.reject(exception));
 
     logger.info(
       `  - CoGateway's inbox message status is ${mintMessageStatus}`,
     );
 
     if (
-      mintMessageStatus === MessageStatus.UNDECLARED ||
-      mintMessageStatus === MessageStatus.REVOKED ||
-      mintMessageStatus === MessageStatus.REVOCATION_DECLARED
+      mintMessageStatus === MessageStatus.UNDECLARED
+      || mintMessageStatus === MessageStatus.REVOKED
+      || mintMessageStatus === MessageStatus.REVOCATION_DECLARED
     ) {
       logger.error('  - Cannot perform progress mint.');
       const err = new TypeError('Message cannot be progressed.');
@@ -1217,18 +1196,16 @@ class Facilitator {
 
     const unstakeMessageStatus = await this.gateway
       .getInboxMessageStatus(messageHash)
-      .catch((exception) => {
-        return Promise.reject(exception);
-      });
+      .catch(exception => Promise.reject(exception));
 
     logger.info(
       `  - Gateway's inbox message status is ${unstakeMessageStatus}`,
     );
 
     if (
-      unstakeMessageStatus === MessageStatus.UNDECLARED ||
-      unstakeMessageStatus === MessageStatus.REVOKED ||
-      unstakeMessageStatus === MessageStatus.REVOCATION_DECLARED
+      unstakeMessageStatus === MessageStatus.UNDECLARED
+      || unstakeMessageStatus === MessageStatus.REVOKED
+      || unstakeMessageStatus === MessageStatus.REVOCATION_DECLARED
     ) {
       logger.info('  - Cannot perform progress unstake.');
       const err = new TypeError('Message cannot be progressed.');
@@ -1283,18 +1260,16 @@ class Facilitator {
 
     const redeemMessageStatus = await this.coGateway
       .getOutboxMessageStatus(messageHash)
-      .catch((exception) => {
-        return Promise.reject(exception);
-      });
+      .catch(exception => Promise.reject(exception));
 
     logger.info(
       `  - CoGateway's outbox message status is ${redeemMessageStatus}`,
     );
 
     if (
-      redeemMessageStatus === MessageStatus.UNDECLARED ||
-      redeemMessageStatus === MessageStatus.REVOCATION_DECLARED ||
-      redeemMessageStatus === MessageStatus.REVOKED
+      redeemMessageStatus === MessageStatus.UNDECLARED
+      || redeemMessageStatus === MessageStatus.REVOCATION_DECLARED
+      || redeemMessageStatus === MessageStatus.REVOKED
     ) {
       logger.info('  - Cannot perform progress redeem.');
       const err = Error('Message cannot be progressed.');
@@ -1336,7 +1311,7 @@ class Facilitator {
         this.mosaic.origin.web3,
         this.mosaic.auxiliary.web3,
       );
-      return this._getProof(
+      return Facilitator._getProof(
         proofGenerator,
         this.gateway.address,
         latestAnchorInfo,
@@ -1363,7 +1338,7 @@ class Facilitator {
         this.mosaic.auxiliary.web3,
         this.mosaic.origin.web3,
       );
-      return this._getProof(
+      return Facilitator._getProof(
         proofGenerator,
         this.coGateway.address,
         latestAnchorInfo,
@@ -1382,7 +1357,7 @@ class Facilitator {
    *
    * @returns {Promise<Object>} Promise that resolves to proof data.
    */
-  async _getProof(
+  static async _getProof(
     proofGenerator,
     accountAddress,
     latestAnchorInfo,
@@ -1449,7 +1424,7 @@ class Facilitator {
    *
    * @returns {Object} An object containing hash lock and unlock secret.
    */
-  getHashLock(unlockSecret) {
+  static getHashLock(unlockSecret) {
     let hashLock = {};
 
     if (unlockSecret === undefined) {

--- a/src/Facilitator/index.js
+++ b/src/Facilitator/index.js
@@ -80,7 +80,8 @@ class Facilitator {
    * @param {string} hashLock Hash lock.
    * @param {Object} txOption Transaction options.
    *
-   * @returns {Promise<Object>} Promise that resolves to transaction receipt.
+   * @returns {Promise<Object>} Promise that resolves to an Object with two properties:
+   *                            messageHash and nonce.
    */
   async stake(
     staker,
@@ -169,12 +170,16 @@ class Facilitator {
         hashLock,
         txOption,
       )
-      .then((stakeResult) => {
+      .then((stakeReceipt) => {
         logger.win('  - Successfully performed stake.');
-        return Promise.resolve(stakeResult);
+        const stakeIntentDeclaredEvent = stakeReceipt.events.StakeIntentDeclared;
+        return Promise.resolve({
+          nonce: stakeIntentDeclaredEvent.returnValues._stakerNonce,
+          messageHash: stakeIntentDeclaredEvent.returnValues._messageHash,
+        });
       })
       .catch((exception) => {
-        logger.error('  - Failed to performed stake.');
+        logger.error('  - Failed to perform stake.');
         return Promise.reject(exception);
       });
   }

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Web3Utils = require('web3-utils');
-const Web3 = require('web3');
+const BN = require('bn.js');
 const Crypto = require('crypto');
+const Web3Utils = require('web3-utils');
 
 /**
  * This class includes the utitity functions.
@@ -68,10 +68,22 @@ class Utils {
       }
 
       tx.send(txOptions)
-        .on('receipt', (receipt) => onResolve(receipt))
-        .on('error', (error) => onReject(error))
-        .catch((exception) => onReject(exception));
+        .on('receipt', receipt => onResolve(receipt))
+        .on('error', error => onReject(error))
+        .catch(exception => onReject(exception));
     });
+  }
+
+  /**
+   * Checks if the max reward exceeds the amount. In that case it could not pay out the expected
+   * reward.
+   * @param {string} amount The amount to stake or redeem.
+   * @param {string} gasPrice Gas price of the reward.
+   * @param {string} gasLimit Gas limit of the process.
+   */
+  static maxRewardTooBig(amount, gasPrice, gasLimit) {
+    const maxReward = new BN(gasPrice).mul(new BN(gasLimit));
+    return (maxReward.gt(new BN(amount)));
   }
 
   /**

--- a/test/EIP20CoGateway/redeemRawTx.js
+++ b/test/EIP20CoGateway/redeemRawTx.js
@@ -82,12 +82,12 @@ describe('EIP20CoGateway.redeemRawTx()', () => {
   });
 
   it('should throw error when beneficiary address is invalid', async () => {
-    const expectedErrorMessage = `Invalid beneficiary address: 0x123.`;
+    const expectedErrorMessage = 'Invalid beneficiary address: 0x123.';
 
     await AssertAsync.reject(
       coGateway.redeemRawTx(
         redeemParams.amount,
-        `0x123`,
+        '0x123',
         redeemParams.gasPrice,
         redeemParams.gasLimit,
         redeemParams.nonce,
@@ -158,6 +158,20 @@ describe('EIP20CoGateway.redeemRawTx()', () => {
         undefined,
       ),
       expectedErrorMessage,
+    );
+  });
+
+  it('should throw an error when the possible reward is greater than the amount', async () => {
+    await AssertAsync.reject(
+      coGateway.redeemRawTx(
+        '99',
+        redeemParams.beneficiary,
+        '2',
+        '50',
+        redeemParams.nonce,
+        redeemParams.hashLock,
+      ),
+      'The maximum possible reward of gasPrice*gasLimit is greater than the redeem amount. It must be less.\n    gasPrice: 2\n    gasLimit: 50\n    redeem amount: 99',
     );
   });
 

--- a/test/EIP20Gateway/stakeRawTx.js
+++ b/test/EIP20Gateway/stakeRawTx.js
@@ -64,7 +64,7 @@ describe('EIP20Gateway.stakeRawTx()', () => {
     );
   });
 
-  it('should throw error when beneficiary address is undefined', async function() {
+  it('should throw error when beneficiary address is undefined', async () => {
     await AssertAsync.reject(
       gateway.stakeRawTx(
         stakeParams.amount,
@@ -78,7 +78,7 @@ describe('EIP20Gateway.stakeRawTx()', () => {
     );
   });
 
-  it('should throw error when gas price is undefined', async function() {
+  it('should throw error when gas price is undefined', async () => {
     await AssertAsync.reject(
       gateway.stakeRawTx(
         stakeParams.amount,
@@ -92,7 +92,7 @@ describe('EIP20Gateway.stakeRawTx()', () => {
     );
   });
 
-  it('should throw error when gas limit is undefined', async function() {
+  it('should throw error when gas limit is undefined', async () => {
     await AssertAsync.reject(
       gateway.stakeRawTx(
         stakeParams.amount,
@@ -131,6 +131,20 @@ describe('EIP20Gateway.stakeRawTx()', () => {
         undefined,
       ),
       'Invalid hash lock: undefined.',
+    );
+  });
+
+  it('should throw an error when the possible reward is greater than the amount', async () => {
+    await AssertAsync.reject(
+      gateway.stakeRawTx(
+        '99',
+        stakeParams.beneficiary,
+        '2',
+        '50',
+        stakeParams.nonce,
+        stakeParams.hashLock,
+      ),
+      'The maximum possible reward of gasPrice*gasLimit is greater than the stake amount. It must be less.\n    gasPrice: 2\n    gasLimit: 50\n    stake amount: 99',
     );
   });
 

--- a/test/Facilitator/getCoGatewayProof.js
+++ b/test/Facilitator/getCoGatewayProof.js
@@ -27,7 +27,7 @@ describe('Facilitator.getCoGatewayProof()', () => {
       sinon.fake.resolves(getLatestAnchorInfoResult),
     );
     spyGetProof = sinon.replace(
-      facilitator,
+      Facilitator,
       '_getProof',
       sinon.fake.resolves(getProofResult),
     );
@@ -41,8 +41,7 @@ describe('Facilitator.getCoGatewayProof()', () => {
   beforeEach(() => {
     mosaic = TestMosaic.mosaic();
     facilitator = new Facilitator(mosaic);
-    messageHash =
-      '0x0000000000000000000000000000000000000000000000000000000000000001';
+    messageHash = '0x0000000000000000000000000000000000000000000000000000000000000001';
     getLatestAnchorInfoResult = sinon.fake();
     getProofResult = true;
   });

--- a/test/Facilitator/getGatewayProof.js
+++ b/test/Facilitator/getGatewayProof.js
@@ -27,7 +27,7 @@ describe('Facilitator.getGatewayProof()', () => {
       sinon.fake.resolves(getLatestAnchorInfoResult),
     );
     spyGetProof = sinon.replace(
-      facilitator,
+      Facilitator,
       '_getProof',
       sinon.fake.resolves(getProofResult),
     );
@@ -41,8 +41,7 @@ describe('Facilitator.getGatewayProof()', () => {
   beforeEach(() => {
     mosaic = TestMosaic.mosaic();
     facilitator = new Facilitator(mosaic);
-    messageHash =
-      '0x0000000000000000000000000000000000000000000000000000000000000001';
+    messageHash = '0x0000000000000000000000000000000000000000000000000000000000000001';
     getLatestAnchorInfoResult = sinon.fake();
     getProofResult = true;
   });

--- a/test/Facilitator/getProof.js
+++ b/test/Facilitator/getProof.js
@@ -11,7 +11,6 @@ const AssertAsync = require('../../test_utils/AssertAsync');
 
 describe('Facilitator._getProof()', () => {
   let mosaic;
-  let facilitator;
 
   let proofGenerator;
   let accountAddress;
@@ -24,8 +23,8 @@ describe('Facilitator._getProof()', () => {
   let spyGetOutboxProof;
   let spyCall;
 
-  let setup = () => {
-    spyCall = sinon.spy(facilitator, '_getProof');
+  const setup = () => {
+    spyCall = sinon.spy(Facilitator, '_getProof');
     mockProofGenerator = sinon.mock(proofGenerator);
     spyGetOutboxProof = sinon.replace(
       mockProofGenerator.object,
@@ -33,14 +32,13 @@ describe('Facilitator._getProof()', () => {
       sinon.fake.resolves(getOutboxProofResult),
     );
   };
-  let teardown = () => {
+  const teardown = () => {
     mockProofGenerator.restore();
     sinon.restore();
     spyCall.restore();
   };
   beforeEach(() => {
     mosaic = TestMosaic.mosaic();
-    facilitator = new Facilitator(mosaic);
     proofGenerator = new ProofGenerator(
       mosaic.auxiliary.web3,
       mosaic.origin.web3,
@@ -51,8 +49,7 @@ describe('Facilitator._getProof()', () => {
       storageProof: [{ serializedProof: '0x3' }],
     };
     accountAddress = '0x0000000000000000000000000000000000000001';
-    messageHash =
-      '0x0000000000000000000000000000000000000000000000000000000000000001';
+    messageHash = '0x0000000000000000000000000000000000000000000000000000000000000001';
     latestAnchorInfo = {
       blockHeight: '100',
       stateRoot:
@@ -62,7 +59,7 @@ describe('Facilitator._getProof()', () => {
 
   it('should throw an error when proofGenerator object is undefined', async () => {
     await AssertAsync.reject(
-      facilitator._getProof(
+      Facilitator._getProof(
         undefined,
         accountAddress,
         latestAnchorInfo,
@@ -74,7 +71,7 @@ describe('Facilitator._getProof()', () => {
 
   it('should throw an error when account address is undefined', async () => {
     await AssertAsync.reject(
-      facilitator._getProof(
+      Facilitator._getProof(
         proofGenerator,
         undefined,
         latestAnchorInfo,
@@ -86,7 +83,7 @@ describe('Facilitator._getProof()', () => {
 
   it('should throw an error when anchor info object is undefined', async () => {
     await AssertAsync.reject(
-      facilitator._getProof(
+      Facilitator._getProof(
         proofGenerator,
         accountAddress,
         undefined,
@@ -98,7 +95,7 @@ describe('Facilitator._getProof()', () => {
 
   it('should throw an error when anchor info object is undefined', async () => {
     await AssertAsync.reject(
-      facilitator._getProof(
+      Facilitator._getProof(
         proofGenerator,
         accountAddress,
         latestAnchorInfo,
@@ -110,7 +107,7 @@ describe('Facilitator._getProof()', () => {
 
   it('should pass when correct params are passed', async () => {
     setup();
-    const result = await facilitator._getProof(
+    const result = await Facilitator._getProof(
       mockProofGenerator.object,
       accountAddress,
       latestAnchorInfo,
@@ -155,9 +152,7 @@ describe('Facilitator._getProof()', () => {
     assert.strictEqual(
       new BN(spyGetOutboxProof.args[0][2].slice(2), 16).toString(10),
       latestAnchorInfo.blockHeight,
-      `Third argument for get outbox proof call must be ${
-        latestAnchorInfo.blockHeight
-      }`,
+      `Third argument for get outbox proof call must be ${latestAnchorInfo.blockHeight}`,
     );
     SpyAssert.assert(spyCall, 1, [
       [

--- a/test/Facilitator/redeem.js
+++ b/test/Facilitator/redeem.js
@@ -8,6 +8,8 @@ const AssertAsync = require('../../test_utils/AssertAsync');
 const SpyAssert = require('../../test_utils/SpyAssert');
 
 describe('Facilitator.redeem()', () => {
+  const messageHash = '0x22ad37e16438758a75c1e31496c7c0eef0d04fc90a2f0fb285f48bb68ef6d28e';
+
   let mosaic;
   let redeemParams;
   let txOptions;
@@ -82,7 +84,16 @@ describe('Facilitator.redeem()', () => {
     approveRedeemAmountResult = true;
     bounty = '100';
     nonce = '1';
-    redeemResult = true;
+    redeemResult = {
+      events: {
+        RedeemIntentDeclared: {
+          returnValues: {
+            _redeemerNonce: nonce,
+            _messageHash: messageHash,
+          },
+        },
+      },
+    };
   });
 
   it('should throw an error when redeemer address is undefined', async () => {
@@ -219,9 +230,7 @@ describe('Facilitator.redeem()', () => {
         redeemParams.hashLock,
         txOptions,
       ),
-      `Value passed in transaction object ${
-        txOptions.value
-      } must be equal to bounty amount ${bounty}`,
+      `Value passed in transaction object ${txOptions.value} must be equal to bounty amount ${bounty}`,
     );
     teardown();
   });
@@ -240,8 +249,8 @@ describe('Facilitator.redeem()', () => {
     );
 
     assert.strictEqual(
-      result,
-      true,
+      result.messageHash,
+      messageHash,
       'Returned valued must match with the expected value',
     );
 
@@ -291,8 +300,8 @@ describe('Facilitator.redeem()', () => {
     );
 
     assert.strictEqual(
-      result,
-      true,
+      result.messageHash,
+      messageHash,
       'Returned valued must match with the expected value',
     );
 
@@ -324,6 +333,33 @@ describe('Facilitator.redeem()', () => {
         txOptions,
       ],
     ]);
+    teardown();
+  });
+
+  it('should return the message hash and nonce', async () => {
+    setup();
+
+    const expectedResponse = {
+      messageHash,
+      nonce,
+    };
+
+    const response = await facilitator.redeem(
+      redeemParams.redeemer,
+      redeemParams.amount,
+      redeemParams.beneficiary,
+      redeemParams.gasPrice,
+      redeemParams.gasLimit,
+      redeemParams.hashLock,
+      txOptions,
+    );
+
+    assert.deepEqual(
+      response,
+      expectedResponse,
+      'Staking did not return the expected parameters.',
+    );
+
     teardown();
   });
 });

--- a/test/Facilitator/stake.js
+++ b/test/Facilitator/stake.js
@@ -18,6 +18,7 @@ describe('Facilitator.stake()', () => {
   let approveStakeAmountResult;
   let approveBountyAmountResult;
   let nonce;
+  let messageHash;
   let stakeResult;
 
   let spyIsStakeAmountApproved;
@@ -88,8 +89,18 @@ describe('Facilitator.stake()', () => {
     isBountyAmountApproved = true;
     approveStakeAmountResult = true;
     approveBountyAmountResult = true;
-    nonce = '1';
-    stakeResult = true;
+    nonce = '3';
+    messageHash = '0x22ad37e16438758a75c1e31496c7c0eef0d04fc90a2f0fb285f48bb68ef6d28e';
+    stakeResult = {
+      events: {
+        StakeIntentDeclared: {
+          returnValues: {
+            _stakerNonce: nonce,
+            _messageHash: messageHash,
+          },
+        },
+      },
+    };
   });
 
   it('should throw an error when staker address is undefined', async () => {
@@ -247,8 +258,8 @@ describe('Facilitator.stake()', () => {
     );
 
     assert.strictEqual(
-      result,
-      true,
+      result.messageHash,
+      messageHash,
       'Returned valued must match with the expected value',
     );
 
@@ -267,7 +278,7 @@ describe('Facilitator.stake()', () => {
         stakeParams.beneficiary,
         stakeParams.gasPrice,
         stakeParams.gasLimit,
-        '1',
+        nonce,
         stakeParams.hashLock,
         txOptions,
       ],
@@ -300,8 +311,8 @@ describe('Facilitator.stake()', () => {
     );
 
     assert.strictEqual(
-      result,
-      true,
+      result.messageHash,
+      messageHash,
       'Returned valued must match with the expected value',
     );
 
@@ -350,8 +361,8 @@ describe('Facilitator.stake()', () => {
     );
 
     assert.strictEqual(
-      result,
-      true,
+      result.messageHash,
+      messageHash,
       'Returned valued must match with the expected value',
     );
 
@@ -368,7 +379,7 @@ describe('Facilitator.stake()', () => {
         stakeParams.beneficiary,
         stakeParams.gasPrice,
         stakeParams.gasLimit,
-        '1',
+        nonce,
         stakeParams.hashLock,
         txOptions,
       ],
@@ -384,6 +395,33 @@ describe('Facilitator.stake()', () => {
         txOptions,
       ],
     ]);
+    teardown();
+  });
+
+  it('should return the message hash and nonce', async () => {
+    setup();
+
+    const expectedResponse = {
+      messageHash,
+      nonce,
+    };
+
+    const response = await facilitator.stake(
+      stakeParams.staker,
+      stakeParams.amount,
+      stakeParams.beneficiary,
+      stakeParams.gasPrice,
+      stakeParams.gasLimit,
+      stakeParams.hashLock,
+      txOptions,
+    );
+
+    assert.deepEqual(
+      response,
+      expectedResponse,
+      'Staking did not return the expected parameters.',
+    );
+
     teardown();
   });
 });

--- a/test_integration/01_sequential_setup/05_eip20_token.js
+++ b/test_integration/01_sequential_setup/05_eip20_token.js
@@ -28,17 +28,22 @@ const assertDeploymentReceipt = (receipt) => {
 };
 
 describe('EIP20Token', async () => {
-  it('should deploy new EIP20Token contract', async () => {
-    const txOptions = {
+  let txOptions;
+  let eip20Contract;
+
+  beforeEach(() => {
+    txOptions = {
       from: shared.setupConfig.deployerAddress,
       gasPrice: shared.setupConfig.gasPrice,
       gasLimit: 700000,
     };
+  });
 
+  it('should deploy new EIP20Token contract', async () => {
     const { web3 } = shared.origin;
-    const contract = new web3.eth.Contract(abi, undefined, txOptions);
+    eip20Contract = new web3.eth.Contract(abi, undefined, txOptions);
 
-    await contract
+    await eip20Contract
       .deploy(
         {
           data: bin,
@@ -58,6 +63,33 @@ describe('EIP20Token', async () => {
       .on('receipt', (receipt) => {
         assertDeploymentReceipt(receipt);
         shared.origin.addresses.EIP20Token = receipt.contractAddress;
+      });
+  });
+
+  it('should deploy new base token contract', async () => {
+    const { web3 } = shared.origin;
+    eip20Contract = new web3.eth.Contract(abi, undefined, txOptions);
+
+    await eip20Contract
+      .deploy(
+        {
+          data: bin,
+          arguments: [
+            'ST',
+            'Simple Token',
+            '800000000000000000000000000', // 800 mio.
+            '18',
+          ],
+        },
+        txOptions,
+      )
+      .send(txOptions)
+      .on('error', (error) => {
+        assert(false, `Could not deploy base token: ${error}`);
+      })
+      .on('receipt', (receipt) => {
+        assertDeploymentReceipt(receipt);
+        shared.origin.addresses.OST = receipt.contractAddress;
       });
   });
 });

--- a/test_integration/01_sequential_setup/06_gateway_helper.js
+++ b/test_integration/01_sequential_setup/06_gateway_helper.js
@@ -19,7 +19,7 @@ const assertReceipt = (receipt) => {
 
 const assertDeploymentReceipt = (receipt) => {
   assertReceipt(receipt);
-  const contractAddress = receipt.contractAddress;
+  const { contractAddress } = receipt;
   assert.isNotEmpty(
     contractAddress,
     'Deployment Receipt is missing contractAddress',
@@ -34,6 +34,7 @@ const assertDeploymentReceipt = (receipt) => {
 describe('GatewayHelper', () => {
   let deployParams;
   let tokenAddress;
+  let baseTokenAddress;
   let anchorAddress;
 
   before(() => {
@@ -43,23 +44,20 @@ describe('GatewayHelper', () => {
     };
 
     tokenAddress = shared.origin.addresses.EIP20Token;
+    baseTokenAddress = shared.origin.addresses.OST;
     anchorAddress = shared.origin.addresses.Anchor;
   });
 
   it('should deploy new Gateway contract', () => {
-    const _token = tokenAddress;
-    const _baseToken = tokenAddress;
-    const _anchor = anchorAddress;
-    const _bounty = 1000;
-
+    const bounty = 1000;
     const subject = new GatewayHelper(shared.origin.web3);
 
     return subject
       .deploy(
-        _token,
-        _baseToken,
-        _anchor,
-        _bounty,
+        tokenAddress,
+        baseTokenAddress,
+        anchorAddress,
+        bounty,
         shared.origin.addresses.Organization,
         shared.origin.addresses.MessageBus,
         shared.origin.addresses.GatewayLib,
@@ -67,18 +65,16 @@ describe('GatewayHelper', () => {
       )
       .then(assertDeploymentReceipt)
       .then((receipt) => {
-        shared.origin.addresses.Gateway = receipt.contractAddress;
+        shared.origin.addresses.EIP20Gateway = receipt.contractAddress;
       });
   });
 
   // Test Setup
   it('should setup Gateway and CoGateway', () => {
-    const simpleToken = tokenAddress;
-
     const gatewayConfig = {
       deployer: shared.setupConfig.deployerAddress,
-      token: simpleToken,
-      baseToken: simpleToken,
+      token: tokenAddress,
+      baseToken: baseTokenAddress,
       organization: shared.origin.addresses.Organization,
       organizationOwner: shared.setupConfig.organizationOwner,
       stateRootProvider: shared.origin.addresses.Anchor,
@@ -90,7 +86,7 @@ describe('GatewayHelper', () => {
 
     const coGatewayConfig = {
       deployer: shared.setupConfig.deployerAddress,
-      valueToken: simpleToken,
+      valueToken: tokenAddress,
       utilityToken: shared.auxiliary.addresses.OSTPrime,
       organization: shared.auxiliary.addresses.Organization,
       stateRootProvider: shared.auxiliary.addresses.Anchor,

--- a/test_integration/01_sequential_setup/07_cogateway_helper.js
+++ b/test_integration/01_sequential_setup/07_cogateway_helper.js
@@ -43,19 +43,15 @@ describe('CoGatewayHelper', () => {
   });
 
   it('should deploy new CoGateway contract', () => {
-    const _token = shared.origin.addresses.EIP20Gateway;
-    const _utilityToken = shared.auxiliary.addresses.OSTPrime;
-    const _anchor = shared.auxiliary.addresses.Anchor;
-    const _bounty = 1000;
-    const _gateway = shared.origin.addresses.EIP20Gateway;
+    const bounty = '10';
 
     return subject
       .deploy(
-        _token,
-        _utilityToken,
-        _anchor,
-        _bounty,
-        _gateway,
+        shared.origin.addresses.EIP20Token,
+        shared.auxiliary.addresses.OSTPrime,
+        shared.auxiliary.addresses.Anchor,
+        bounty,
+        shared.origin.addresses.EIP20Gateway,
         shared.auxiliary.addresses.Organization,
         shared.auxiliary.addresses.MessageBus,
         shared.auxiliary.addresses.GatewayLib,

--- a/test_integration/01_sequential_setup/07_cogateway_helper.js
+++ b/test_integration/01_sequential_setup/07_cogateway_helper.js
@@ -18,7 +18,7 @@ const assertReceipt = (receipt) => {
 
 const assertDeploymentReceipt = (receipt) => {
   assertReceipt(receipt);
-  const contractAddress = receipt.contractAddress;
+  const { contractAddress } = receipt;
   assert.isNotEmpty(
     contractAddress,
     'Deployment Receipt is missing contractAddress',
@@ -42,13 +42,12 @@ describe('CoGatewayHelper', () => {
     };
   });
 
-  const someValidAddress = '0x2222222222222222222222222222222222222222';
   it('should deploy new CoGateway contract', () => {
-    const _token = someValidAddress;
+    const _token = shared.origin.addresses.EIP20Gateway;
     const _utilityToken = shared.auxiliary.addresses.OSTPrime;
     const _anchor = shared.auxiliary.addresses.Anchor;
     const _bounty = 1000;
-    const _gateway = shared.origin.addresses.Gateway;
+    const _gateway = shared.origin.addresses.EIP20Gateway;
 
     return subject
       .deploy(
@@ -64,7 +63,7 @@ describe('CoGatewayHelper', () => {
       )
       .then(assertDeploymentReceipt)
       .then((receipt) => {
-        shared.auxiliary.addresses.CoGateway = receipt.contractAddress;
+        shared.auxiliary.addresses.EIP20CoGateway = receipt.contractAddress;
       });
   });
 });

--- a/test_integration/01_sequential_setup/08_activation.js
+++ b/test_integration/01_sequential_setup/08_activation.js
@@ -34,7 +34,7 @@ describe('Activate deployed contracts', () => {
   });
 
   it('should set CoGateway on OSTPrime', () => {
-    const addressCoGateway = shared.auxiliary.addresses.CoGateway;
+    const addressCoGateway = shared.auxiliary.addresses.EIP20CoGateway;
     const txOptions = {
       from: shared.setupConfig.organizationOwner,
     };
@@ -49,14 +49,14 @@ describe('Activate deployed contracts', () => {
   });
 
   it('should activate gateway', () => {
-    const addressCoGateway = shared.auxiliary.addresses.CoGateway;
+    const addressCoGateway = shared.auxiliary.addresses.EIP20CoGateway;
     const txOptions = {
       from: shared.setupConfig.organizationOwner,
     };
 
     const subject = new GatewayHelper(
       shared.origin.web3,
-      shared.origin.addresses.Gateway,
+      shared.origin.addresses.EIP20Gateway,
     );
     return subject
       .activateGateway(addressCoGateway, txOptions)

--- a/test_integration/02_setup_module/03_gateways.js
+++ b/test_integration/02_setup_module/03_gateways.js
@@ -22,22 +22,19 @@ describe('Setup.gateways', () => {
 
   it('should deploy new gateways', async () => {
     const originConfig = {
-      // Placeholders for token addresses:
       token: shared.origin.addresses.EIP20Token,
-      baseToken: shared.origin.addresses.EIP20Token,
+      baseToken: shared.origin.addresses.OST,
       stateRootProvider: shared.setupModule.originAnchor.address,
-      bounty: '0',
+      bounty: '10',
       organization: shared.setupModule.originOrganization.address,
       burner: ZERO_ADDRESS,
       deployer: shared.setupConfig.deployerAddress,
       organizationOwner: shared.setupConfig.deployerAddress,
     };
     const auxiliaryConfig = {
-      // Placeholders for token addresses:
-      valueToken: shared.auxiliary.addresses.OSTPrime,
       utilityToken: shared.auxiliary.addresses.OSTPrime,
       stateRootProvider: shared.setupModule.auxiliaryAnchor.address,
-      bounty: '0',
+      bounty: '10',
       organization: shared.setupModule.auxiliaryOrganization.address,
       burner: ZERO_ADDRESS,
       deployer: shared.setupConfig.deployerAddress,
@@ -63,5 +60,8 @@ describe('Setup.gateways', () => {
       true,
       `CoGateway does not have a valid address: ${auxiliaryCoGateway.address}`,
     );
+
+    shared.setupModule.originGateway = originGateway.address;
+    shared.setupModule.auxiliaryCoGateway = auxiliaryCoGateway.address;
   });
 });

--- a/test_integration/03_stake/01_stake_helper.js
+++ b/test_integration/03_stake/01_stake_helper.js
@@ -2,6 +2,7 @@
 
 const { assert } = require('chai');
 const BN = require('bn.js');
+const { abi } = require('../contracts/EIP20Token.json');
 const StakeHelper = require('../../src/helpers/StakeHelper');
 const shared = require('../shared');
 
@@ -14,8 +15,8 @@ const validateReceipt = (receipt) => {
 };
 
 describe('StakeHelper', () => {
-  const amountToStake = new BN('10000000000');
-  let amountToApprove;
+  const amountToStake = '10000000000';
+  let bountyAmount;
 
   it('should generate valid hashLock', () => {
     const expectedOutput = {
@@ -42,7 +43,7 @@ describe('StakeHelper', () => {
       .getNonce(
         shared.setupConfig.deployerAddress,
         shared.origin.web3,
-        shared.origin.addresses.Gateway,
+        shared.origin.addresses.EIP20Gateway,
       )
       .then((stakerNonce) => {
         assert.equal(1, stakerNonce, 'Staker nonce should be 1');
@@ -55,13 +56,10 @@ describe('StakeHelper', () => {
       .getBounty(
         shared.setupConfig.deployerAddress,
         shared.origin.web3,
-        shared.origin.addresses.Gateway,
+        shared.origin.addresses.EIP20Gateway,
       )
       .then((bounty) => {
-        const bnBounty = new BN(bounty);
-        // The below amount will be reused in the following test.
-        amountToApprove = bnBounty.add(amountToStake).toString(10);
-        console.log('### Amount to approve', amountToApprove);
+        bountyAmount = new BN(bounty);
       });
   });
 
@@ -69,25 +67,40 @@ describe('StakeHelper', () => {
     const helper = new StakeHelper();
     return helper
       .approveStakeAmount(
-        amountToApprove,
+        amountToStake,
         undefined,
         shared.origin.web3,
         shared.origin.addresses.EIP20Token,
-        shared.origin.addresses.Gateway,
+        shared.origin.addresses.EIP20Gateway,
         shared.setupConfig.deployerAddress,
       )
+      .then(validateReceipt);
+  });
+
+  it('should approve bounty amount', async () => {
+    const baseToken = new shared.origin.web3.eth.Contract(
+      abi,
+      shared.origin.addresses.OST,
+    );
+
+    return baseToken.methods
+      .approve(
+        shared.origin.addresses.EIP20Gateway,
+        bountyAmount.toString(10),
+      )
+      .send({ from: shared.setupConfig.deployerAddress })
       .then(validateReceipt);
   });
 
   it('should perform staking', () => {
     const helper = new StakeHelper(
       shared.origin.web3,
-      // FIXME: The following line should become OST if #136 gets merged:
-      shared.origin.addresses.EIP20Token,
+      shared.origin.addresses.OST,
       shared.origin.addresses.EIP20Token,
       shared.origin.addresses.Gateway,
       shared.setupConfig.deployerAddress,
     );
+    helper.valueToken = shared.origin.addresses.EIP20Token;
 
     // Only for testing purposes we re-use the same address:
     const beneficiary = shared.setupConfig.deployerAddress;

--- a/test_integration/03_stake/01_stake_helper.js
+++ b/test_integration/03_stake/01_stake_helper.js
@@ -95,12 +95,11 @@ describe('StakeHelper', () => {
   it('should perform staking', () => {
     const helper = new StakeHelper(
       shared.origin.web3,
-      shared.origin.addresses.OST,
       shared.origin.addresses.EIP20Token,
-      shared.origin.addresses.Gateway,
+      shared.origin.addresses.OST,
+      shared.origin.addresses.EIP20Gateway,
       shared.setupConfig.deployerAddress,
     );
-    helper.valueToken = shared.origin.addresses.EIP20Token;
 
     // Only for testing purposes we re-use the same address:
     const beneficiary = shared.setupConfig.deployerAddress;

--- a/test_integration/03_stake/02_facilitator.js
+++ b/test_integration/03_stake/02_facilitator.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { assert } = require('chai');
+
+const Chain = require('../../src/Chain');
+const Facilitator = require('../../src/Facilitator');
+const Mosaic = require('../../src/Mosaic');
+const Utils = require('../../src/utils/Utils');
+const shared = require('../shared');
+
+describe('Facilitator.stake()', () => {
+  const amount = '1000000000';
+  const gasPrice = '5';
+  const gasLimit = '20000000';
+
+  let staker;
+  let beneficiary;
+  let txOptions;
+  let mosaic;
+
+  beforeEach(() => {
+    staker = shared.setupConfig.deployerAddress;
+    beneficiary = shared.setupConfig.deployerAddress;
+    txOptions = {
+      from: shared.setupConfig.deployerAddress,
+      gasPrice: shared.origin.gasPrice,
+      gas: 7000000,
+    };
+
+    // Using the gateways from the setup module, as the other gateway has already been staked in the
+    // previous integration test `01_stake_helper.js`.
+    const origin = new Chain(
+      shared.origin.web3,
+      { EIP20Gateway: shared.setupModule.originGateway },
+    );
+    const auxiliary = new Chain(
+      shared.auxiliary.web3,
+      { EIP20CoGateway: shared.setupModule.auxiliaryCoGateway },
+    );
+    mosaic = new Mosaic(origin, auxiliary);
+  });
+
+  it('should return nonce and message hash', async () => {
+    const { hashLock } = Utils.createSecretHashLock();
+
+    const facilitator = new Facilitator(mosaic);
+
+    const response = await facilitator.stake(
+      staker,
+      amount,
+      beneficiary,
+      gasPrice,
+      gasLimit,
+      hashLock,
+      txOptions,
+    );
+
+    assert.typeOf(response.messageHash, 'string', 'The message hash must be part of the response.');
+    assert.strictEqual(response.nonce, '1', 'The nonce should be 1 for the first call.');
+  });
+});

--- a/test_integration/03_stake/02_facilitator.js
+++ b/test_integration/03_stake/02_facilitator.js
@@ -18,6 +18,8 @@ describe('Facilitator.stake()', () => {
   let txOptions;
   let mosaic;
 
+  let hashLock;
+
   beforeEach(() => {
     staker = shared.setupConfig.deployerAddress;
     beneficiary = shared.setupConfig.deployerAddress;
@@ -40,8 +42,8 @@ describe('Facilitator.stake()', () => {
     mosaic = new Mosaic(origin, auxiliary);
   });
 
-  it('should return nonce and message hash', async () => {
-    const { hashLock } = Utils.createSecretHashLock();
+  it('should stake', async () => {
+    hashLock = Utils.createSecretHashLock();
 
     const facilitator = new Facilitator(mosaic);
 
@@ -51,11 +53,47 @@ describe('Facilitator.stake()', () => {
       beneficiary,
       gasPrice,
       gasLimit,
-      hashLock,
+      hashLock.hashLock,
       txOptions,
     );
 
     assert.typeOf(response.messageHash, 'string', 'The message hash must be part of the response.');
     assert.strictEqual(response.nonce, '1', 'The nonce should be 1 for the first call.');
   });
+
+  // FIXME: Add this test as soon as we use a test node that can generate proofs.
+  // The current augurproject/dev-node-geth cannot.
+  // Response to getting proof:
+  // {"jsonrpc":"2.0","id":1551373707415,"result":null}
+  //
+  // Use `response` from previous test to access required fields.
+  //
+  // it('should progress stake', async () => {
+  //   // First we need to make the state root known on target.
+  //   const anchor = new Anchor(shared.auxiliary.web3, shared.auxiliary.addresses.Anchor);
+  //   const block = await shared.origin.web3.eth.getBlock('latest');
+  //   await anchor.anchorStateRoot(
+  //     block.number.toString(),
+  //     block.stateRoot,
+  //     {
+  //       ...txOptions,
+  //       from: shared.setupConfig.organizationOwner,
+  //     },
+  //   );
+  //
+  //   console.log('Progressing Stake');
+  //   const facilitator = new Facilitator(mosaic);
+  //   await facilitator.progressStake(
+  //     staker,
+  //     amount,
+  //     beneficiary,
+  //     gasPrice,
+  //     gasLimit,
+  //     stakingResponse.nonce.toString(),
+  //     hashLock.hashLock,
+  //     hashLock.unlockSecret,
+  //     txOptions,
+  //     txOptions,
+  //   );
+  // });
 });

--- a/test_integration/docker-compose.yml
+++ b/test_integration/docker-compose.yml
@@ -3,11 +3,11 @@ version: "3"
 services:
 
   geth_node_origin:
-    image: augurproject/dev-node-geth:v1.8.18
+    image: augurproject/dev-node-geth:latest
     ports:
       - "8546:8545"
 
   geth_node_auxiliary:
-    image: augurproject/dev-node-geth:v1.8.18
+    image: augurproject/dev-node-geth:latest
     ports:
       - "8547:8545"

--- a/test_integration/integration_tests.js
+++ b/test_integration/integration_tests.js
@@ -19,12 +19,12 @@ const runTests = async () => {
 
   Mocha.utils
     .lookupFiles(__dirname, ['js'], true)
-    .filter((file) => file.substr(-20) !== 'integration_tests.js')
+    .filter(file => file.substr(-20) !== 'integration_tests.js')
     .forEach((file) => {
       mocha.addFile(file);
     });
 
-  mocha.run(function(failures) {
+  mocha.run((failures) => {
     dockerTeardown();
     process.exitCode = failures ? 1 : 0;
   });


### PR DESCRIPTION
`Facilitator.stake()` now returns nonce and message hash. The events
are part of the web3 PromiEvent response and can be easily parsed from
the return object.

Refactored Facilitator. The stake function was too verbose. I extracted
some methods out to make the stake function more readable.

Updated integration tests to use different value token and base token.
Doing this also revealed the bug in the StakeHelper. The integration
tests now deploy two separate EIP20 tokens for base token and value
token. Those are now set on the Gateway and CoGateway as baes token and
value token.

The EIP20Gateway contract interact did not catch the case where the
possible reward is higher than the stake amount and the contract
reverts. I added the check as part of this ticket as it was a difficult
to track issue I faced with integration tests.

Added unit tests for facilitator and gateway. The facilitator stake unit
test now includes the response of nonce and message hash. The gateway
stake unit test now includes the check for the amount to be greater than
gas price times gas limit.

Added integration test for facilitator. I created a new file in the
integration test directory and let the facilitator stake with the
gateways that were deployd as part of the setup module integration test.
Because of the proper token setup on the gateways, I had to add a line
to the stake helper functional test where I set the value token (ref. #137)

Various linting errors fixed.

Fixes #136