### PR TITLE
StakeHelper now accepts value token in constructor

### DIFF
--- a/src/helpers/StakeHelper.js
+++ b/src/helpers/StakeHelper.js
@@ -7,7 +7,7 @@ const Contracts = require('../Contracts');
 const Utils = require('../utils/Utils');
 
 class StakeHelper {
-  constructor(originWeb3, simpleToken, gateway, staker, txOptions, valueToken) {
+  constructor(originWeb3, valueToken, simpleToken, gateway, staker, txOptions) {
     Utils.deprecationNoticeStakeHelper();
 
     const oThis = this;
@@ -149,17 +149,17 @@ class StakeHelper {
     console.log(`* Approving Stake Amount`);
     return tx
       .send(txOptions)
-      .on('transactionHash', function(transactionHash) {
+      .on('transactionHash', function (transactionHash) {
         console.log('\t - transaction hash:', transactionHash);
       })
-      .on('receipt', function(receipt) {
+      .on('receipt', function (receipt) {
         console.log(
           '\t - Receipt:\n\x1b[2m',
           JSON.stringify(receipt),
           '\x1b[0m\n',
         );
       })
-      .on('error', function(error) {
+      .on('error', function (error) {
         console.log('\t !! Error !!', error, '\n\t !! ERROR !!\n');
         return Promise.reject(error);
       });
@@ -228,17 +228,17 @@ class StakeHelper {
     console.log(`* Staking SimpleToken`);
     return tx
       .send(txOptions)
-      .on('transactionHash', function(transactionHash) {
+      .on('transactionHash', function (transactionHash) {
         console.log('\t - transaction hash:', transactionHash);
       })
-      .on('receipt', function(receipt) {
+      .on('receipt', function (receipt) {
         console.log(
           '\t - Receipt:\n\x1b[2m',
           JSON.stringify(receipt),
           '\x1b[0m\n',
         );
       })
-      .on('error', function(error) {
+      .on('error', function (error) {
         console.log('\t !! Error !!', error, '\n\t !! ERROR !!\n');
         return Promise.reject(error);
       });

--- a/src/helpers/StakeHelper.js
+++ b/src/helpers/StakeHelper.js
@@ -7,12 +7,12 @@ const Contracts = require('../Contracts');
 const Utils = require('../utils/Utils');
 
 class StakeHelper {
-  constructor(originWeb3, simpleToken, gateway, staker, txOptions) {
+  constructor(originWeb3, simpleToken, gateway, staker, txOptions, valueToken) {
     Utils.deprecationNoticeStakeHelper();
 
     const oThis = this;
     oThis.web3 = originWeb3;
-    oThis.valueToken = simpleToken;
+    oThis.valueToken = valueToken;
     oThis.simpleToken = simpleToken;
     oThis.gateway = gateway;
     oThis.staker = staker;

--- a/test_integration/03_stake/01_stake_helper.js
+++ b/test_integration/03_stake/01_stake_helper.js
@@ -85,6 +85,9 @@ describe('StakeHelper', () => {
       shared.origin.addresses.EIP20Token,
       shared.origin.addresses.Gateway,
       shared.setupConfig.deployerAddress,
+      undefined,
+      // FIXME: The following line should become OST if #136 gets merged:
+      shared.origin.addresses.EIP20Token,
     );
 
     // Only for testing purposes we re-use the same address:

--- a/test_integration/03_stake/01_stake_helper.js
+++ b/test_integration/03_stake/01_stake_helper.js
@@ -82,12 +82,11 @@ describe('StakeHelper', () => {
   it('should perform staking', () => {
     const helper = new StakeHelper(
       shared.origin.web3,
+      // FIXME: The following line should become OST if #136 gets merged:
+      shared.origin.addresses.EIP20Token,
       shared.origin.addresses.EIP20Token,
       shared.origin.addresses.Gateway,
       shared.setupConfig.deployerAddress,
-      undefined,
-      // FIXME: The following line should become OST if #136 gets merged:
-      shared.origin.addresses.EIP20Token,
     );
 
     // Only for testing purposes we re-use the same address:

--- a/tests/helpers/StakeHelper.js
+++ b/tests/helpers/StakeHelper.js
@@ -230,7 +230,7 @@ describe('tests/ChainSetup', function() {
 
   it('should perform staking', function() {
     this.timeout(30 * 60 * 1000); //30 Minutes
-    let helper = new StakeHelper(web3, caMockToken, caGateway, staker);
+    let helper = new StakeHelper(web3, caMockToken, caMockToken, caGateway, staker);
     let _amount = amountToStake;
     let _beneficiary = staker;
     let _gasPrice = '0';


### PR DESCRIPTION
The stake helper sets both the value token and the simple token members
to the given simple token. This lead to errors in integration tests when
working on #136.

I propose this solution, where the argument is added at the end of the
constructor. This way, I would assume that KIT is not affected. I am
*guessing* that KIT does what I did in the integration test of #136:
they set `stakeHelper.valueToken` after initializing it.

Let's discuss if this is a viable solution or if we can offer something
else.

Fixes #137