### PR TITLE
Anchor: blockheight as number and string

### DIFF
--- a/src/ContractInteract/Anchor.js
+++ b/src/ContractInteract/Anchor.js
@@ -288,7 +288,7 @@ class Anchor {
    * @returns {Promise<Object>} Promise that resolves to transaction receipt.
    */
   anchorStateRoot(blockHeight, stateRoot, txOptions) {
-    if (isNaN(blockHeight)) {
+    if (typeof blockHeight !== 'string' && typeof blockHeight !== 'number') {
       const err = new TypeError(`Invalid block height: ${blockHeight}.`);
       return Promise.reject(err);
     }

--- a/src/ContractInteract/Anchor.js
+++ b/src/ContractInteract/Anchor.js
@@ -288,7 +288,7 @@ class Anchor {
    * @returns {Promise<Object>} Promise that resolves to transaction receipt.
    */
   anchorStateRoot(blockHeight, stateRoot, txOptions) {
-    if (typeof blockHeight !== 'string') {
+    if (isNaN(blockHeight)) {
       const err = new TypeError(`Invalid block height: ${blockHeight}.`);
       return Promise.reject(err);
     }

--- a/test/Anchor/anchorStateRoot.js
+++ b/test/Anchor/anchorStateRoot.js
@@ -53,6 +53,39 @@ describe('Anchor.anchorStateRoot', () => {
     SpyAssert.assert(spySendTransaction, 1, [[mockTx, txOptions]]);
   });
 
+  it('should pass when called with block height as number', async () => {
+    sinon.restore();
+    let blockHeight = 10;
+    let stateRoot = web3.utils.sha3('1');
+    let mockTx = 'mockTx';
+
+    let txOptions = {
+      from: '0x0000000000000000000000000000000000000003',
+    };
+
+    let spyAnchorStateRoot = sinon.replace(
+      anchor.contract.methods,
+      'anchorStateRoot',
+      sinon.fake.returns(mockTx),
+    );
+
+    let spySendTransaction = sinon.replace(
+      Utils,
+      'sendTransaction',
+      sinon.fake.resolves(true),
+    );
+    let result = await anchor.anchorStateRoot(
+      blockHeight,
+      stateRoot,
+      txOptions,
+    );
+
+    assert.isTrue(result, 'Anchor state root should return true');
+
+    SpyAssert.assert(spyAnchorStateRoot, 1, [[blockHeight, stateRoot]]);
+
+  });
+
   it('should throw for undefined block height', async () => {
     let blockHeight = undefined;
     let stateRoot = web3.utils.sha3('1');


### PR DESCRIPTION
PR contains :- 
1.  Changes done to accept string and number as blockheight.
2. Added test case to pass when blockheight is number instead of string.

Fixes: #143 